### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # GasCalc - A Cheap Solution
-This script basically just calculates gas prices in proximity by scrapeing data off search.
+This script basically just calculates gas prices in proximity by scrapeing data off search on some random website.
+# View in Repl.it!
+[![Run on Repl.it](https://repl.it/badge/github/Nels2/GasCalc)](https://repl.it/github/Nels2/GasCalc)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@nels277/GasCalc).